### PR TITLE
Redirect GitHub Pages to Vercel

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Redirecting… | 安心ダッシン</title>
+<link rel="canonical" href="https://ng-2406.vercel.app/">
+<meta name="robots" content="noindex">
+<meta http-equiv="refresh" content="0; url=https://ng-2406.vercel.app/">
+<script>
+  location.replace("https://ng-2406.vercel.app/" + location.search + location.hash);
+</script>
+</head>
+<body>
+<p>新しいURLに移動しました: <a href="https://ng-2406.vercel.app/">https://ng-2406.vercel.app/</a></p>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Redirecting… | 安心ダッシン</title>
+<link rel="canonical" href="https://ng-2406.vercel.app/">
+<meta name="robots" content="noindex">
+<meta http-equiv="refresh" content="0; url=https://ng-2406.vercel.app/">
+<script>
+  location.replace("https://ng-2406.vercel.app/" + location.search + location.hash);
+</script>
+</head>
+<body>
+<p>新しいURLに移動しました: <a href="https://ng-2406.vercel.app/">https://ng-2406.vercel.app/</a></p>
+</body>
+</html>


### PR DESCRIPTION
以前のURLである https://jphacks.github.io/ng_2406/ にアクセスしても、 https://ng-2406.vercel.app/ にリダイレクトされるように変更